### PR TITLE
Add overrides as extra-properties to enhance the default YAML 1.1 bool behavior

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include *.yml *.yaml *.ini LICENSE README.md requirements.txt
 recursive-include src/yacfg/profiles *
 recursive-include src/yacfg/templates *
 recursive-include tests *.py
+recursive-include tests *.yaml
 recursive-include docs *.md
 recursive-include docs *.rst
 recursive-include docs *.yml

--- a/src/yacfg/cli_arguments.py
+++ b/src/yacfg/cli_arguments.py
@@ -51,6 +51,12 @@ group_main.add_argument(
 )
 
 group_main.add_argument(
+    '--extra-properties',
+    help='Extra properties (key-value pairs) that can be used by specific templates'
+         ' Example: {x:y,a:b}'
+)
+
+group_main.add_argument(
     '--opt',
     metavar='KEY=VALUE',
     help=(

--- a/src/yacfg/templates/artemis/2.15.0/modules/broker_xml/address_settings.jinja2
+++ b/src/yacfg/templates/artemis/2.15.0/modules/broker_xml/address_settings.jinja2
@@ -4,10 +4,10 @@
             {% for address_setting in broker_xml.address_settings %}
             <address-setting match="{{ address_setting.match }}">
                 {% if address_setting.dead_letter_address is defined %}
-                <dead-letter-address>{{ address_setting.dead_letter_address }}</dead-letter-address>
+                <dead-letter-address>{{ address_setting.dead_letter_address|overridevalue(address_setting.match + 'dead_letter_address') }}</dead-letter-address>
                 {% endif %}
                 {% if address_setting.expiry_address is defined %}
-                <expiry-address>{{ address_setting.expiry_address }}</expiry-address>
+                <expiry-address>{{ address_setting.expiry_address|overridevalue(address_setting.match + 'expiry_address') }}</expiry-address>
                 {% endif %}
                 {% if address_setting.redelivery_delay is defined %}
                 <redelivery-delay>{{ address_setting.redelivery_delay }}</redelivery-delay>
@@ -16,13 +16,13 @@
                 <redistribution-delay>{{ address_setting.redistribution_delay }}</redistribution-delay>
                 {% endif %}
                 {% if address_setting.max_size_bytes is defined %}
-                <max-size-bytes>{{ address_setting.max_size_bytes }}</max-size-bytes>
+                <max-size-bytes>{{ address_setting.max_size_bytes|overridevalue(address_setting.match + 'max_size_bytes') }}</max-size-bytes>
                 {% endif %}
                 {% if address_setting.message_counter_history_day_limit is defined %}
                 <message-counter-history-day-limit>{{ address_setting.message_counter_history_day_limit }}</message-counter-history-day-limit>
                 {% endif %}
                 {% if address_setting.address_full_policy is defined %}
-                <address-full-policy>{{ address_setting.address_full_policy }}</address-full-policy>
+                <address-full-policy>{{ address_setting.address_full_policy|overridevalue(address_setting.match + 'address_full_policy') }}</address-full-policy>
                 {% endif %}
                 {% if address_setting.auto_create_queues is defined %}
                 <auto-create-queues>{{ mbool(address_setting.auto_create_queues) }}</auto-create-queues>
@@ -43,10 +43,10 @@
                 <max-size-bytes-reject-threshold>{{ address_setting.max_size_bytes_reject_threshold }}</max-size-bytes-reject-threshold>
                 {% endif %}
                 {% if address_setting.default_address_routing_type is defined %}
-                <default-address-routing-type>{{ address_setting.default_address_routing_type }}</default-address-routing-type>
+                <default-address-routing-type>{{ address_setting.default_address_routing_type|overridevalue(address_setting.match + 'default_address_routing_type') }}</default-address-routing-type>
                 {% endif %}
                 {% if address_setting.config_delete_addresses is defined %}
-                <config-delete-addresses>{{ address_setting.config_delete_addresses }}</config-delete-addresses>
+                <config-delete-addresses>{{ address_setting.config_delete_addresses|overridevalue(address_setting.match + 'config_delete_addresses') }}</config-delete-addresses>
                 {% endif %}
                 {% if address_setting.default_non_destructive is defined %}
                 <default-non-destructive>{{ mbool(address_setting.default_non_destructive) }}</default-non-destructive>
@@ -73,16 +73,16 @@
                 <send-to-dla-on-no-route>{{ mbool(address_setting.send_to_dla_on_no_route) }}</send-to-dla-on-no-route>
                 {% endif %}
                 {% if address_setting.default_last_value_key is defined %}
-                <default-last-value-key>{{ address_setting.default_last_value_key }}</default-last-value-key>
+                <default-last-value-key>{{ address_setting.default_last_value_key|overridevalue(address_setting.match + 'default_last_value_key') }}</default-last-value-key>
                 {% endif %}
                 {% if address_setting.slow_consumer_policy is defined %}
-                <slow-consumer-policy>{{ address_setting.slow_consumer_policy }}</slow-consumer-policy>
+                <slow-consumer-policy>{{ address_setting.slow_consumer_policy|overridevalue(address_setting.match + 'slow_consumer_policy') }}</slow-consumer-policy>
                 {% endif %}
                 {% if address_setting.auto_delete_jms_topics is defined %}
                 <auto-delete-jms-topics>{{ mbool(address_setting.auto_delete_jms_topics) }}</auto-delete-jms-topics>
                 {% endif %}
                 {% if address_setting.default_group_first_key is defined %}
-                <default-group-first-key>{{ address_setting.default_group_first_key }}</default-group-first-key>
+                <default-group-first-key>{{ address_setting.default_group_first_key|overridevalue(address_setting.match + 'default_group_first_key') }}</default-group-first-key>
                 {% endif %}
                 {% if address_setting.enable_metrics is defined %}
                 <enable-metrics>{{ mbool(address_setting.enable_metrics) }}</enable-metrics>
@@ -91,7 +91,7 @@
                 <min-expiry-delay>{{ address_setting.min_expiry_delay }}</min-expiry-delay>
                 {% endif %}
                 {% if address_setting.dead_letter_queue_suffix is defined %}
-                <dead-letter-queue-suffix>{{ address_setting.dead_letter_queue_suffix }}</dead-letter-queue-suffix>
+                <dead-letter-queue-suffix>{{ address_setting.dead_letter_queue_suffix|overridevalue(address_setting.match + 'dead_letter_queue_suffix') }}</dead-letter-queue-suffix>
                 {% endif %}
                 {% if address_setting.default_group_buckets is defined %}
                 <default-group-buckets>{{ address_setting.default_group_buckets }}</default-group-buckets>
@@ -103,7 +103,7 @@
                 <retroactive-message-count>{{ address_setting.retroactive_message_count }}</retroactive-message-count>
                 {% endif %}
                 {% if address_setting.dead_letter_queue_prefix is defined %}
-                <dead-letter-queue-prefix>{{ address_setting.dead_letter_queue_prefix }}</dead-letter-queue-prefix>
+                <dead-letter-queue-prefix>{{ address_setting.dead_letter_queue_prefix|overridevalue(address_setting.match + 'dead_letter_queue_prefix') }}</dead-letter-queue-prefix>
                 {% endif %}
                 {% if address_setting.default_ring_size is defined %}
                 <default-ring-size>{{ address_setting.default_ring_size }}</default-ring-size>
@@ -151,7 +151,7 @@
                 <max-redelivery-delay>{{ address_setting.max_redelivery_delay }}</max-redelivery-delay>
                 {% endif %}
                 {% if address_setting.default_queue_routing_type is defined %}
-                <default-queue-routing-type>{{ address_setting.default_queue_routing_type }}</default-queue-routing-type>
+                <default-queue-routing-type>{{ address_setting.default_queue_routing_type|overridevalue(address_setting.match + 'default_queue_routing_type') }}</default-queue-routing-type>
                 {% endif %}
                 {% if address_setting.slow_consumer_check_period is defined %}
                 <slow-consumer-check-period>{{ address_setting.slow_consumer_check_period }}</slow-consumer-check-period>
@@ -160,7 +160,7 @@
                 <slow-consumer-threshold>{{ address_setting.slow_consumer_threshold }}</slow-consumer-threshold>
                 {% endif %}
                 {% if address_setting.config_delete_queues is defined %}
-                <config-delete-queues>{{ address_setting.config_delete_queues }}</config-delete-queues>
+                <config-delete-queues>{{ address_setting.config_delete_queues|overridevalue(address_setting.match + 'config_delete_queues') }}</config-delete-queues>
                 {% endif %}
                 {% if address_setting.management_browse_page_size is defined %}
                 <management-browse-page-size>{{ address_setting.management_browse_page_size }}</management-browse-page-size>
@@ -169,13 +169,13 @@
                 <auto-delete-queues>{{ mbool(address_setting.auto_delete_queues) }}</auto-delete-queues>
                 {% endif %}
                 {% if address_setting.expiry_queue_suffix is defined %}
-                <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix }}</expiry-queue-suffix>
+                <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix|overridevalue(address_setting.match + 'expiry_queue_suffix') }}</expiry-queue-suffix>
                 {% endif %}
                 {% if address_setting.auto_delete_queues_message_count is defined %}
                 <auto-delete-queues-message-count>{{ address_setting.auto_delete_queues_message_count }}</auto-delete-queues-message-count>
                 {% endif %}
                 {% if address_setting.expiry_queue_prefix is defined %}
-                <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix }}</expiry-queue-prefix>
+                <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix|overridevalue(address_setting.match + 'expiry_queue_prefix') }}</expiry-queue-prefix>
                 {% endif %}
                 {% if address_setting.default_purge_on_no_consumers is defined %}
                 <default-purge-on-no-consumers>{{ mbool(address_setting.default_purge_on_no_consumers) }}</default-purge-on-no-consumers>
@@ -184,7 +184,7 @@
                 <default-exclusive-queue>{{ mbool(address_setting.default_exclusive_queue) }}</default-exclusive-queue>
                 {% endif %}
                 {% if address_setting.page_size_bytes is defined %}
-                <page-size-bytes>{{ address_setting.page_size_bytes }}</page-size-bytes>
+                <page-size-bytes>{{ address_setting.page_size_bytes|overridevalue(address_setting.match + 'page_size_bytes') }}</page-size-bytes>
                 {% endif %}
             </address-setting>
                 {% if not loop.last %}

--- a/src/yacfg/templates/artemis/2.16.0/modules/broker_xml/address_settings.jinja2
+++ b/src/yacfg/templates/artemis/2.16.0/modules/broker_xml/address_settings.jinja2
@@ -4,10 +4,10 @@
             {% for address_setting in broker_xml.address_settings %}
             <address-setting match="{{ address_setting.match }}">
                 {% if address_setting.dead_letter_address is defined %}
-                <dead-letter-address>{{ address_setting.dead_letter_address }}</dead-letter-address>
+                <dead-letter-address>{{ address_setting.dead_letter_address|overridevalue(address_setting.match + 'dead_letter_address') }}</dead-letter-address>
                 {% endif %}
                 {% if address_setting.expiry_address is defined %}
-                <expiry-address>{{ address_setting.expiry_address }}</expiry-address>
+                <expiry-address>{{ address_setting.expiry_address|overridevalue(address_setting.match + 'expiry_address') }}</expiry-address>
                 {% endif %}
                 {% if address_setting.redelivery_delay is defined %}
                 <redelivery-delay>{{ address_setting.redelivery_delay }}</redelivery-delay>
@@ -16,13 +16,13 @@
                 <redistribution-delay>{{ address_setting.redistribution_delay }}</redistribution-delay>
                 {% endif %}
                 {% if address_setting.max_size_bytes is defined %}
-                <max-size-bytes>{{ address_setting.max_size_bytes }}</max-size-bytes>
+                <max-size-bytes>{{ address_setting.max_size_bytes|overridevalue(address_setting.match + 'max_size_bytes') }}</max-size-bytes>
                 {% endif %}
                 {% if address_setting.message_counter_history_day_limit is defined %}
                 <message-counter-history-day-limit>{{ address_setting.message_counter_history_day_limit }}</message-counter-history-day-limit>
                 {% endif %}
                 {% if address_setting.address_full_policy is defined %}
-                <address-full-policy>{{ address_setting.address_full_policy }}</address-full-policy>
+                <address-full-policy>{{ address_setting.address_full_policy|overridevalue(address_setting.match + 'address_full_policy') }}</address-full-policy>
                 {% endif %}
                 {% if address_setting.auto_create_queues is defined %}
                 <auto-create-queues>{{ mbool(address_setting.auto_create_queues) }}</auto-create-queues>
@@ -43,10 +43,10 @@
                 <max-size-bytes-reject-threshold>{{ address_setting.max_size_bytes_reject_threshold }}</max-size-bytes-reject-threshold>
                 {% endif %}
                 {% if address_setting.default_address_routing_type is defined %}
-                <default-address-routing-type>{{ address_setting.default_address_routing_type }}</default-address-routing-type>
+                <default-address-routing-type>{{ address_setting.default_address_routing_type|overridevalue(address_setting.match + 'default_address_routing_type') }}</default-address-routing-type>
                 {% endif %}
                 {% if address_setting.config_delete_addresses is defined %}
-                <config-delete-addresses>{{ address_setting.config_delete_addresses }}</config-delete-addresses>
+                <config-delete-addresses>{{ address_setting.config_delete_addresses|overridevalue(address_setting.match + 'config_delete_addresses') }}</config-delete-addresses>
                 {% endif %}
                 {% if address_setting.default_non_destructive is defined %}
                 <default-non-destructive>{{ mbool(address_setting.default_non_destructive) }}</default-non-destructive>
@@ -73,16 +73,16 @@
                 <send-to-dla-on-no-route>{{ mbool(address_setting.send_to_dla_on_no_route) }}</send-to-dla-on-no-route>
                 {% endif %}
                 {% if address_setting.default_last_value_key is defined %}
-                <default-last-value-key>{{ address_setting.default_last_value_key }}</default-last-value-key>
+                <default-last-value-key>{{ address_setting.default_last_value_key|overridevalue(address_setting.match + 'default_last_value_key') }}</default-last-value-key>
                 {% endif %}
                 {% if address_setting.slow_consumer_policy is defined %}
-                <slow-consumer-policy>{{ address_setting.slow_consumer_policy }}</slow-consumer-policy>
+                <slow-consumer-policy>{{ address_setting.slow_consumer_policy|overridevalue(address_setting.match + 'slow_consumer_policy') }}</slow-consumer-policy>
                 {% endif %}
                 {% if address_setting.auto_delete_jms_topics is defined %}
                 <auto-delete-jms-topics>{{ mbool(address_setting.auto_delete_jms_topics) }}</auto-delete-jms-topics>
                 {% endif %}
                 {% if address_setting.default_group_first_key is defined %}
-                <default-group-first-key>{{ address_setting.default_group_first_key }}</default-group-first-key>
+                <default-group-first-key>{{ address_setting.default_group_first_key|overridevalue(address_setting.match + 'default_group_first_key') }}</default-group-first-key>
                 {% endif %}
                 {% if address_setting.enable_metrics is defined %}
                 <enable-metrics>{{ mbool(address_setting.enable_metrics) }}</enable-metrics>
@@ -91,7 +91,7 @@
                 <min-expiry-delay>{{ address_setting.min_expiry_delay }}</min-expiry-delay>
                 {% endif %}
                 {% if address_setting.dead_letter_queue_suffix is defined %}
-                <dead-letter-queue-suffix>{{ address_setting.dead_letter_queue_suffix }}</dead-letter-queue-suffix>
+                <dead-letter-queue-suffix>{{ address_setting.dead_letter_queue_suffix|overridevalue(address_setting.match + 'dead_letter_queue_suffix') }}</dead-letter-queue-suffix>
                 {% endif %}
                 {% if address_setting.default_group_buckets is defined %}
                 <default-group-buckets>{{ address_setting.default_group_buckets }}</default-group-buckets>
@@ -103,7 +103,7 @@
                 <retroactive-message-count>{{ address_setting.retroactive_message_count }}</retroactive-message-count>
                 {% endif %}
                 {% if address_setting.dead_letter_queue_prefix is defined %}
-                <dead-letter-queue-prefix>{{ address_setting.dead_letter_queue_prefix }}</dead-letter-queue-prefix>
+                <dead-letter-queue-prefix>{{ address_setting.dead_letter_queue_prefix|overridevalue(address_setting.match + 'dead_letter_queue_prefix') }}</dead-letter-queue-prefix>
                 {% endif %}
                 {% if address_setting.default_ring_size is defined %}
                 <default-ring-size>{{ address_setting.default_ring_size }}</default-ring-size>
@@ -151,7 +151,7 @@
                 <max-redelivery-delay>{{ address_setting.max_redelivery_delay }}</max-redelivery-delay>
                 {% endif %}
                 {% if address_setting.default_queue_routing_type is defined %}
-                <default-queue-routing-type>{{ address_setting.default_queue_routing_type }}</default-queue-routing-type>
+                <default-queue-routing-type>{{ address_setting.default_queue_routing_type|overridevalue(address_setting.match + 'default_queue_routing_type') }}</default-queue-routing-type>
                 {% endif %}
                 {% if address_setting.slow_consumer_check_period is defined %}
                 <slow-consumer-check-period>{{ address_setting.slow_consumer_check_period }}</slow-consumer-check-period>
@@ -160,7 +160,7 @@
                 <slow-consumer-threshold>{{ address_setting.slow_consumer_threshold }}</slow-consumer-threshold>
                 {% endif %}
                 {% if address_setting.config_delete_queues is defined %}
-                <config-delete-queues>{{ address_setting.config_delete_queues }}</config-delete-queues>
+                <config-delete-queues>{{ address_setting.config_delete_queues|overridevalue(address_setting.match + 'config_delete_queues') }}</config-delete-queues>
                 {% endif %}
                 {% if address_setting.management_browse_page_size is defined %}
                 <management-browse-page-size>{{ address_setting.management_browse_page_size }}</management-browse-page-size>
@@ -169,13 +169,13 @@
                 <auto-delete-queues>{{ mbool(address_setting.auto_delete_queues) }}</auto-delete-queues>
                 {% endif %}
                 {% if address_setting.expiry_queue_suffix is defined %}
-                <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix }}</expiry-queue-suffix>
+                <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix|overridevalue(address_setting.match + 'expiry_queue_suffix') }}</expiry-queue-suffix>
                 {% endif %}
                 {% if address_setting.auto_delete_queues_message_count is defined %}
                 <auto-delete-queues-message-count>{{ address_setting.auto_delete_queues_message_count }}</auto-delete-queues-message-count>
                 {% endif %}
                 {% if address_setting.expiry_queue_prefix is defined %}
-                <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix }}</expiry-queue-prefix>
+                <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix|overridevalue(address_setting.match + 'expiry_queue_prefix') }}</expiry-queue-prefix>
                 {% endif %}
                 {% if address_setting.default_purge_on_no_consumers is defined %}
                 <default-purge-on-no-consumers>{{ mbool(address_setting.default_purge_on_no_consumers) }}</default-purge-on-no-consumers>
@@ -184,7 +184,7 @@
                 <default-exclusive-queue>{{ mbool(address_setting.default_exclusive_queue) }}</default-exclusive-queue>
                 {% endif %}
                 {% if address_setting.page_size_bytes is defined %}
-                <page-size-bytes>{{ address_setting.page_size_bytes }}</page-size-bytes>
+                <page-size-bytes>{{ address_setting.page_size_bytes|overridevalue(address_setting.match + 'page_size_bytes') }}</page-size-bytes>
                 {% endif %}
             </address-setting>
                 {% if not loop.last %}

--- a/src/yacfg/yacfg_cli.py
+++ b/src/yacfg/yacfg_cli.py
@@ -159,7 +159,8 @@ def main():
             render_options=render_options,
             tuning_files_list=options.tune,
             tuning_data_list=options.opt,
-            write_profile_data=options.save_effective_profile
+            write_profile_data=options.save_effective_profile,
+            extra_properties_data=options.extra_properties
         )
     except TemplateError as exc:
         error(exc)

--- a/tests/extras/test_broker_special_char.py
+++ b/tests/extras/test_broker_special_char.py
@@ -1,0 +1,57 @@
+# Copyright 2018 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yacfg
+import shutil
+import os
+
+
+def test_with_special_chars(*_):
+
+    tune_file = 'tune_files/special_address_setting.yaml'
+    project_root = os.environ.get('YACFG_PROJECT_ROOT')
+    if project_root is not None:
+        tune_file = project_root + '/tests/extras/' + tune_file
+
+    profile = 'artemis/2.16.0/default_with_user_address_settings.yaml.jinja2'
+    tuning_files = [tune_file]
+    extra_props = "{'#dead_letter_queue_prefix':'','#config_delete_queues':'OFF'}"
+    output = 'etc'
+
+    yacfg.generate(
+        profile=profile,
+        tuning_files_list=tuning_files,
+        extra_properties_data=extra_props,
+        output_path=output
+    )
+
+    broker_xml = output + '/broker.xml'
+    file1 = open(broker_xml, 'r')
+    try:
+        lines = file1.readlines()
+
+        empty_found = False
+        off_found = False
+        for ln in lines:
+            if ln.find('<dead-letter-queue-prefix></dead-letter-queue-prefix>') != -1:
+                empty_found = True
+            if ln.find('<config-delete-queues>OFF</config-delete-queues>') != -1:
+                off_found = True
+
+        assert empty_found is True
+        assert off_found is True
+
+    finally:
+        file1.close()
+        shutil.rmtree(output)

--- a/tests/extras/tune_files/special_address_setting.yaml
+++ b/tests/extras/tune_files/special_address_setting.yaml
@@ -1,0 +1,22 @@
+# yacfg tuning file generated from profile artemis/2.16.0/default_with_user_address_settings.yaml.jinja2
+---
+broker_home: /opt/artemis-2.16.0
+broker_instance: /opt/artemis-2.16.0-i0
+broker_name: amq
+log_level_all: INFO
+log_level_audit_base: ERROR
+log_level_audit_message: ERROR
+log_level_handler_audit_file: INFO
+log_level_handler_console: DEBUG
+log_level_handler_file: DEBUG
+log_level_integration: INFO
+log_level_jetty: WARN
+log_level_jms: INFO
+log_level_journal: INFO
+log_level_server: INFO
+log_level_utils: INFO
+user_address_settings:
+  - address_full_policy: PAGE
+    match: '#'
+    dead_letter_queue_prefix:
+    config_delete_queues: OFF

--- a/tests/test_yacfg/profiles/fakes.py
+++ b/tests/test_yacfg/profiles/fakes.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import jinja2
+
 def fake_get_tuned_profile_data(*_):
     return {'_defaults': {'default_key': 'default_value'}, 'key': 'value'}
 
@@ -41,6 +43,10 @@ def fake_load_tuned_profile_no_defaults(*_, **kwargs):
             'key: value\n'
         )
     )
+
+
+def fake_template_environment(*_):
+    return jinja2.Environment()
 
 
 def fake_load_tuned_profile_w_template(*_, **kwargs):

--- a/tests/test_yacfg/test_generate.py
+++ b/tests/test_yacfg/test_generate.py
@@ -20,7 +20,8 @@ from yacfg.yacfg import generate
 from yacfg.exceptions import ProfileError, TemplateError
 from .profiles.fakes import (
     fake_load_tuned_profile_no_defaults,
-    fake_load_tuned_profile_w_template
+    fake_load_tuned_profile_w_template,
+    fake_template_environment
 )
 
 
@@ -28,7 +29,8 @@ from .profiles.fakes import (
             side_effect=fake_load_tuned_profile_no_defaults)
 @mock.patch('yacfg.yacfg.add_template_metadata', mock.Mock())
 @mock.patch('yacfg.yacfg.add_render_config', mock.Mock())
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -70,7 +72,8 @@ def test_true_render_options(*_):
 
 
 @mock.patch('yacfg.yacfg.get_tuned_profile', mock.Mock())
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -116,7 +119,8 @@ def test_true_tuning_files(*_):
 
 @mock.patch('yacfg.yacfg.get_tuned_profile',
             side_effect=fake_load_tuned_profile_no_defaults)
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -165,7 +169,8 @@ def test_true_tuning_data(*_):
 
 @mock.patch('yacfg.yacfg.get_tuned_profile',
             side_effect=fake_load_tuned_profile_no_defaults)
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -202,7 +207,8 @@ def test_true_no_output_path_write_profile(*_):
 
 @mock.patch('yacfg.yacfg.get_tuned_profile',
             side_effect=fake_load_tuned_profile_no_defaults)
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -241,7 +247,8 @@ def test_true_output_path_write_profile(*_):
 
 @mock.patch('yacfg.yacfg.get_tuned_profile',
             side_effect=fake_load_tuned_profile_no_defaults)
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -279,7 +286,8 @@ def test_true_output_path(*_):
 
 @mock.patch('yacfg.yacfg.get_tuned_profile',
             side_effect=fake_load_tuned_profile_no_defaults)
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -315,7 +323,8 @@ def test_true_template(*_):
 
 @mock.patch('yacfg.yacfg.get_tuned_profile',
             side_effect=fake_load_tuned_profile_w_template)
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())

--- a/tests/test_yacfg/test_generate_core.py
+++ b/tests/test_yacfg/test_generate_core.py
@@ -20,13 +20,15 @@ from yacfg.yacfg import generate_core
 from yacfg.exceptions import TemplateError
 from .profiles.fakes import (
     fake_load_tuned_profile_no_defaults,
-    fake_load_tuned_profile_w_template
+    fake_load_tuned_profile_w_template,
+    fake_template_environment
 )
 
 
 @mock.patch('yacfg.yacfg.add_template_metadata', mock.Mock())
 @mock.patch('yacfg.yacfg.add_render_config', mock.Mock())
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -66,7 +68,8 @@ def test_true(*_):
     yacfg.yacfg.generate_outputs.assert_called()
 
 
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -102,7 +105,8 @@ def test_true_no_output_path_write_profile(*_):
     yacfg.yacfg.generate_outputs.assert_called()
 
 
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -137,7 +141,8 @@ def test_true_output_path_write_no_profile(*_):
     yacfg.yacfg.generate_outputs.assert_called()
 
 
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -175,7 +180,8 @@ def test_true_output_path_write_profile(*_):
     yacfg.yacfg.generate_outputs.assert_called()
 
 
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -212,7 +218,8 @@ def test_true_output_path(*_):
     yacfg.yacfg.generate_outputs.assert_called()
 
 
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())
@@ -246,7 +253,8 @@ def test_true_template(*_):
     yacfg.yacfg.generate_outputs.assert_called()
 
 
-@mock.patch('yacfg.yacfg.get_template_environment', mock.Mock())
+@mock.patch('yacfg.yacfg.get_template_environment',
+            side_effect=fake_template_environment)
 @mock.patch('yacfg.yacfg.get_main_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.filter_template_list', mock.Mock())
 @mock.patch('yacfg.yacfg.ensure_output_path', mock.Mock())


### PR DESCRIPTION
Due to YAML 1.1 spec https://yaml.org/type/bool.html some values can be interpreted as boolean values and therefore generated wrong results.

To workaround this an extra_properties option to yacfg is added so that the caller can pass in some 'extra' information as a key-value set. A filter is then added to check out on the extra properties and make proper overrides.

Fixes #24