### PR TITLE
export YACFG_PROJECT_ROOT

### DIFF
--- a/.github/workflows/master.pull_request.workflow.yaml
+++ b/.github/workflows/master.pull_request.workflow.yaml
@@ -30,7 +30,9 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade coverage[toml] virtualenv tox tox-gh-actions
       - name: "Run tox targets for ${{ matrix.python-version }}"
-        run: tox
+        run: |
+          export YACFG_PROJECT_ROOT=$PWD
+          tox
       - name: "Get coverage"
         run: |
           set -xe

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ python =
     pypy3: pypy3
 
 [testenv]
+passenv = YACFG_PROJECT_ROOT
 extras = testing
 setenv =
     PYTHONUNBUFFERED=yes


### PR DESCRIPTION
Fixes #25 
Export YACFG_PROJECT_ROOT so that the test can find/locate its resource files.