### PR TITLE
Fix error when user doesn't provide optional extra properties

### DIFF
--- a/src/yacfg/yacfg.py
+++ b/src/yacfg/yacfg.py
@@ -102,7 +102,7 @@ def generate_core(config_data, tuned_profile=None, template=None,
         :type value_key: str
         :return: str
         """
-        if value_key in extra_properties_data:
+        if extra_properties_data is not None and value_key in extra_properties_data:
             return extra_properties_data[value_key]
         return value
 


### PR DESCRIPTION
Fixes #33
When user doesn't provide any extra properties the iteration on [extra_properties_data](https://github.com/rh-messaging-qe/yacfg/blob/master/src/yacfg/yacfg.py#L105) will throw error:
`if value_key in extra_properties_data:
TypeError: argument of type 'NoneType' is not iterable
`
It should check the extra_properties_data before iterating.