### PR TITLE
Allow running the yacfg scripts directly; use absolute imports, add shebang, and fixup `sys.path` if needed

### DIFF
--- a/src/yacfg/cli/cli_arguments.py
+++ b/src/yacfg/cli/cli_arguments.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env -S python3 -sP
+
 from __future__ import annotations
 
 import argparse

--- a/src/yacfg/cli/cli_arguments.py
+++ b/src/yacfg/cli/cli_arguments.py
@@ -5,7 +5,7 @@ import json
 import re
 from typing import Dict, List, Tuple, Union
 
-from .. import DESCRIPTION, NAME, __version__
+from yacfg import DESCRIPTION, NAME, __version__
 
 REX_BOOL_TRUE = re.compile(r"^(true|yes|1|on)$", re.IGNORECASE)
 REX_BOOL_FALSE = re.compile(r"^(false|no|0|off)$", re.IGNORECASE)
@@ -210,5 +210,5 @@ group_misc.add_argument(
     "--version", help="Display version information", action="store_true"
 )
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     args = parser.parse_args()

--- a/src/yacfg/cli/yacfg_cli.py
+++ b/src/yacfg/cli/yacfg_cli.py
@@ -8,7 +8,12 @@ from yacfg import NAME, __version__, logger_settings
 from yacfg.cli.cli_arguments import boolize, parse_key_value_list, parser
 from yacfg.config_data import RenderOptions
 from yacfg.exceptions import GenerationError, ProfileError, TemplateError
-from yacfg.output import export_tuning_variables, new_profile, new_profile_rendered, new_template
+from yacfg.output import (
+    export_tuning_variables,
+    new_profile,
+    new_profile_rendered,
+    new_template,
+)
 from yacfg.query import list_profiles, list_templates
 from yacfg.yacfg import generate
 
@@ -104,10 +109,10 @@ class CommandLineApp:
                     self.error(str(exc), 0)
 
         if (
-                options.new_profile
-                or options.new_profile_static
-                or options.export_tuning
-                or options.new_template
+            options.new_profile
+            or options.new_profile_static
+            or options.export_tuning
+            or options.new_template
         ):
             sys.exit(0)
 
@@ -147,5 +152,5 @@ def main():
     app.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/yacfg/cli/yacfg_cli.py
+++ b/src/yacfg/cli/yacfg_cli.py
@@ -1,19 +1,16 @@
+#! /usr/bin/env -S python3 -sP
+
 import logging
 import os
 import sys
 
-from .. import NAME, __version__, logger_settings
+from yacfg import NAME, __version__, logger_settings
 from yacfg.cli.cli_arguments import boolize, parse_key_value_list, parser
-from ..config_data import RenderOptions
-from ..exceptions import GenerationError, ProfileError, TemplateError
-from ..output import (
-    export_tuning_variables,
-    new_profile,
-    new_profile_rendered,
-    new_template,
-)
-from ..query import list_profiles, list_templates
-from ..yacfg import generate
+from yacfg.config_data import RenderOptions
+from yacfg.exceptions import GenerationError, ProfileError, TemplateError
+from yacfg.output import export_tuning_variables, new_profile, new_profile_rendered, new_template
+from yacfg.query import list_profiles, list_templates
+from yacfg.yacfg import generate
 
 logger_settings.config_console_logger()
 
@@ -107,10 +104,10 @@ class CommandLineApp:
                     self.error(str(exc), 0)
 
         if (
-            options.new_profile
-            or options.new_profile_static
-            or options.export_tuning
-            or options.new_template
+                options.new_profile
+                or options.new_profile_static
+                or options.export_tuning
+                or options.new_template
         ):
             sys.exit(0)
 
@@ -148,3 +145,7 @@ class CommandLineApp:
 def main():
     app = CommandLineApp()
     app.run()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/yacfg/files.py
+++ b/src/yacfg/files.py
@@ -108,13 +108,17 @@ def select_profile_file(profile_name: str) -> Tuple[str, str]:
         # User-defined profile in the ./profiles/ directory
         LOG.debug(f"User-defined profile in the ./profiles/ directory: {profile_name}")
         profile_tmp_name = os.path.abspath(user_extra_path)
-        selected_profile_name, selected_profile_path = os.path.basename(profile_tmp_name), os.path.dirname(profile_tmp_name)
+        selected_profile_name, selected_profile_path = os.path.basename(
+            profile_tmp_name
+        ), os.path.dirname(profile_tmp_name)
 
     if os.path.isfile(profile_name):
         # User directly specified the profile file
         LOG.debug(f"User directly specified the profile file: {profile_name}")
         profile_tmp_name = os.path.abspath(profile_name)
-        selected_profile_name, selected_profile_path = os.path.basename(profile_tmp_name), os.path.dirname(profile_tmp_name)
+        selected_profile_name, selected_profile_path = os.path.basename(
+            profile_tmp_name
+        ), os.path.dirname(profile_tmp_name)
 
     profiles_paths = get_profiles_paths()
     LOG.debug(f"Profiles paths: {profiles_paths}")
@@ -150,17 +154,15 @@ def select_template_dir(template_name: str) -> str:
 
     if os.path.isdir(user_extra_path):
         selected_template_path = user_extra_path
-        LOG.debug(f'Using user defined template path {template_name}')
+        LOG.debug(f"Using user defined template path {template_name}")
 
     # user direct path
     if os.path.isdir(template_name):
         selected_template_path = template_name
-        LOG.debug(f'Using user defined template path {template_name}')
+        LOG.debug(f"Using user defined template path {template_name}")
 
     if not os.path.isdir(selected_template_path):
-        raise TemplateError(
-            f'Unable to load requested template set "{template_name}"'
-        )
+        raise TemplateError(f'Unable to load requested template set "{template_name}"')
 
     if not os.path.isfile(os.path.join(selected_template_path, "_template")):
         raise TemplateError(
@@ -170,7 +172,6 @@ def select_template_dir(template_name: str) -> str:
 
     LOG.debug(f"Selected template: {selected_template_path}")
     return selected_template_path
-
 
 
 def ensure_output_path(output_path: str) -> None:

--- a/src/yacfg/yacfg.py
+++ b/src/yacfg/yacfg.py
@@ -263,7 +263,7 @@ def generate_outputs(
     generate_exception: Optional[GenerationError] = None
 
     # TODO: volkswagen mode on
-    if 'PYTEST_CURRENT_TEST' not in os.environ:
+    if "PYTEST_CURRENT_TEST" not in os.environ:
         if output_path and not os.path.exists(output_path):
             raise GenerationError(f"Output path '{output_path}' does not exist.")
 

--- a/src/yacfg_batch/yacfg_batch_cli.py
+++ b/src/yacfg_batch/yacfg_batch_cli.py
@@ -1,13 +1,24 @@
+#! /usr/bin/env -S python3 -sP
+
 from __future__ import print_function
 
 import logging
+import pathlib
 import sys
+
+# `from yacfg_batch import ...` may target both src/yacfg/yacfg_batch/__init__.py
+# and src/yacfg/yacfg_batch/yacfg_batch.py (which is on sys.path when running
+# this file directly). Remove the undesirable sys.path entry to prevent `ImportError`s.
+try:
+    sys.path.remove(str(pathlib.Path(__file__).resolve().parent))
+except ValueError:
+    pass
 
 from yacfg import NAME, logger_settings
 
-from . import __version__
-from .cli_arguments import parser
-from .yacfg_batch import generate
+from yacfg_batch import __version__
+from yacfg_batch.cli_arguments import parser
+from yacfg_batch.yacfg_batch import generate
 
 logger_settings.config_console_logger()
 


### PR DESCRIPTION
Fixes

```
ImportError: attempted relative import with no known parent package
```

## Proposed Changes (What, How, and Why)

Shebang has been added at the beginning of yacfg_batch_cli.py and yacfg_cli.py to allow script execution. The import statements have been updated to avoid 'ImportError'. Unnecessary sys.path entries are removed to guard against import misdirection. Also, a script entry point check has been added at the end of yacfg_cli.py.